### PR TITLE
Prevent PurifyCSS warnings

### DIFF
--- a/manuscript/styling/04_eliminating_unused_css.md
+++ b/manuscript/styling/04_eliminating_unused_css.md
@@ -114,7 +114,7 @@ const productionConfig = merge([
   ...
 leanpub-start-insert
   parts.purifyCSS({
-    paths: glob.sync(path.join(PATHS.app, '**', '*')),
+    paths: glob.sync(path.join(PATHS.app, '**', '*'), { nodir: true }),
   }),
 leanpub-end-insert
 ]);


### PR DESCRIPTION
Without `, { nodir: true }` the glob will check for directories too which ends in warnings.