### PR TITLE
Update 04_what_is_webpack.md

### DIFF
--- a/manuscript/04_what_is_webpack.md
+++ b/manuscript/04_what_is_webpack.md
@@ -8,11 +8,9 @@ T> If you want to understand build tools and their history in a better detail, c
 
 ## Webpack Relies on Modules
 
-If you think about the smallest project you could bundle with webpack, you’ll end up with input and output. In webpack terms, the bundling process begins from user defined **entries**. Entries themselves are **modules** and can point to other modules through **imports**.
+The way to think about webpack is that you supply it with input and it gives you back output. In webpack terms, the bundling process begins from user defined **entries**. An entry is a starting point from which webpack will follow references to other modules and from these modules will follow references to other modules and so on. As a result, webpack constructs a **dependency graph** of the project and then generates the **output** based on your configuration. It writes everything into a single **bundle** by default, but it can be configured to output more.
 
-When you bundle a project through webpack, it traverses through imports. As a result, webpack constructs a **dependency graph** of the project and then generates the **output** based on the configuration. It writes everything into a single **bundle** by default, but it can be configured to output more.
-
-Webpack supports ES6, CommonJS, and AMD module formats out of the box. The loader mechanism works for CSS as well, and `@import` and `url()` are supported through *css-loader*. You can also find plugins for specific tasks, such as minification, internationalization, HMR, and so on.
+When it comes to JavaScript, webpack supports ES6, CommonJS, and AMD module formats out of the box, but modules don't have to be JavaScript modules. The loader mechanism works for CSS as well, and `@import` and `url()` are supported through *css-loader* but through the use of other loaders, other types of file (like fonts or images) can be imported. This is one of the things that makes webpack so powerful.
 
 T> A dependency graph describes is a directed graph that describes how nodes relate to each other. In this case the graph definition is defined through references (`require`, `import`) between files. Webpack can traverse this information in a static manner without executing the source to generate the graph it needs to create bundles.
 


### PR DESCRIPTION
- Rewrite 'Webpack relies on modules' section. This is really important and I found it confusing. I've tried to get across:

1. Idea of input and output
2. Idea of dependency graph
3. Idea that module doesn't have to be JS (this was missing).

I removed: 'You can also find plugins for specific tasks, such as minification, internationalization, HMR, and so on' as it is confusing at this point because it doesn't directly relate to modules.