### PR TITLE
Fix stats.json

### DIFF
--- a/manuscript/optimizing/01_minifying.md
+++ b/manuscript/optimizing/01_minifying.md
@@ -228,6 +228,7 @@ exports.minifyCSS = ({ options }) => ({
     new OptimizeCSSAssetsPlugin({
       cssProcessor: cssnano,
       cssProcessorOptions: options,
+      canPrint: false,
     }),
   ],
 });


### PR DESCRIPTION
Without `canPrint: false,` the output of `webpack --env production --profile --json > stats.json` is broken. See https://github.com/NMFR/optimize-css-assets-webpack-plugin/issues/4.