### PR TITLE
add missing webpack variable in webpack.config.js

### DIFF
--- a/manuscript/building/02_splitting_bundles.md
+++ b/manuscript/building/02_splitting_bundles.md
@@ -139,6 +139,12 @@ W> Webpack doesn't allow referring to entry files within entries. If you inadver
 **webpack.config.js**
 
 ```javascript
+leanpub-start-insert
+const webpack = require('webpack');
+leanpub-end-insert
+
+  ...
+
 const commonConfig = merge([
   {
     entry: {


### PR DESCRIPTION
the variable `webpack` was not declared in the code sample for webpack.config.js from [Setting Up CommonsChunkPlugin section](https://survivejs.com/webpack/building/splitting-bundles/#setting-up-commonschunkplugin-)