### PR TITLE
add file name when setting up a project for i18n

### DIFF
--- a/manuscript/techniques/03_i18n.md
+++ b/manuscript/techniques/03_i18n.md
@@ -20,6 +20,8 @@ To illustrate the setup, *i18n-webpack-plugin* is a good starting point.
 
 To prove that translation works, there should be an entry point that has something to replace:
 
+**app/i18n.js**
+
 ```javascript
 console.log(__('Hello world'));
 ```


### PR DESCRIPTION
the name of the file containing the 'hello world' sample code for [i18n](https://survivejs.com/webpack/techniques/i18n/#setting-up-a-project) is missing