### PR TITLE
change commonConfig['entry'] to be in sync with npm run build:lib output

### DIFF
--- a/manuscript/output/02_bundling_libraries.md
+++ b/manuscript/output/02_bundling_libraries.md
@@ -55,7 +55,7 @@ const PATHS = {
 const commonConfig = merge([
   {
     entry: {
-      demo: PATHS.lib,
+      lib: PATHS.lib,
     },
     output: {
       path: PATHS.build,


### PR DESCRIPTION
In [Bundling Libraries chapter](https://survivejs.com/webpack/output/bundling-libraries/), when [Setting Up Webpack](https://survivejs.com/webpack/output/bundling-libraries/#setting-up-webpack), the `commonConfig[ 'entry' ]` from webpack.lib.js and the output of the command `npm run build:lib` are out of sync (

> entry: { **demo**: PATHS.lib, }

 vs 

> **lib**.js  2.96 kB       0  [emitted]  lib

).

I chose to edit `commonConfig[ 'entry' ]`, so we'll have `entry: { lib: PATHS.lib, }`. (This will also be in sync with your paragraph from the [same page](https://survivejs.com/webpack/output/bundling-libraries/#setting-up-webpack) where you mention `dist/lib.js`.)