### PR TITLE
add missing var 'path' in karma config file

### DIFF
--- a/manuscript/techniques/04_testing.md
+++ b/manuscript/techniques/04_testing.md
@@ -366,6 +366,11 @@ On Karma side, reporting has to be set up and Karma configuration has to be conn
 **karma.conf.js**
 
 ```javascript
+leanpub-start-insert
+const path = require('path');
+leanpub-end-insert
+...
+
 module.exports = (config) => {
   ...
 


### PR DESCRIPTION
`path` variable is not declared in `karma.conf.js` when setting up for [Coverage Reports](https://survivejs.com/webpack/techniques/testing/#generating-coverage-reports).

You may also consider adding a remark somewhere in that chapter saying that all commands involving PhantomJS from that chapter (like `npm run test:karma:watch`) will raise an error if run prior to this final config added in `karma.conf.js` (our test code contains ES6 features, latest stable PhantomJS 2.1 doesn't support ES6 -but [2.5 will](https://github.com/ariya/phantomjs/issues/14506#issuecomment-251611067)-, so code needs to be transpiled to ES5).