### PR TITLE
Suggest disabling instead of enabling 'safe write' @ IDE settings

### DIFF
--- a/manuscript/developing/02_automatic_browser_refresh.md
+++ b/manuscript/developing/02_automatic_browser_refresh.md
@@ -30,7 +30,7 @@ npm install webpack-dev-server --save-dev
 
 As before, this command generates a command below the `npm bin` directory and you could run *webpack-dev-server* from there. After running the WDS, you have a development server running at `http://localhost:8080`. Automatic browser refresh is in place now, although at a basic level.
 
-W> If you are using an IDE, consider enabling **save write** from its settings. This way WDS is able to detect changes made to the files correctly.
+W> If you are using an IDE, consider enabling **safe write** from its settings. This way WDS is able to detect changes made to the files correctly.
 
 ## Attaching WDS to the Project
 

--- a/manuscript/developing/02_automatic_browser_refresh.md
+++ b/manuscript/developing/02_automatic_browser_refresh.md
@@ -30,7 +30,7 @@ npm install webpack-dev-server --save-dev
 
 As before, this command generates a command below the `npm bin` directory and you could run *webpack-dev-server* from there. After running the WDS, you have a development server running at `http://localhost:8080`. Automatic browser refresh is in place now, although at a basic level.
 
-W> If you are using an IDE, consider enabling **safe write** from its settings. This way WDS is able to detect changes made to the files correctly.
+W> If you are using an IDE, consider disabling **safe write** from its settings. This way WDS is able to detect changes made to the files correctly.
 
 ## Attaching WDS to the Project
 


### PR DESCRIPTION
This change aligns the book with _Webpack_ docs, as seen @ https://webpack.github.io/docs/webpack-dev-server.html#working-with-editors-ides-supporting-safe-write.

However, I'm slightly confused (as a non _safe-write_ user :P). Judging from [this commit](https://github.com/survivejs/webpack-book/commit/d844a3932176b9068bdd2a4c79c1c2cf227032aa) on January, 30th (which removes a similar warning from a previous section), it seems like the underlying problem has been fixed @ watchpack (concretely, thanks to [this commit](https://github.com/webpack/watchpack/pull/17) from September, 2015), and therefore this warning doesn't apply anymore for Webpack 2.

@bebraw Time to get rid of the warning altogether instead of fixing it?

