### PR TITLE
Fix comment regarding 'devServer.overlay' option

### DIFF
--- a/manuscript/developing/03_linting.md
+++ b/manuscript/developing/03_linting.md
@@ -178,7 +178,7 @@ const developmentConfig = () => {
     devServer: {
       ...
 leanpub-start-insert
-      // overlay: true captures only errors
+      // overlay: true is equivalent
       overlay: {
         errors: true,
         warnings: true,


### PR DESCRIPTION
Implemented @ https://github.com/webpack/webpack-dev-server/pull/790, `overlay: true` captures warnings too.

Source code where both settings are set to the same _boolean_ value can be found @ https://github.com/webpack/webpack-dev-server/blob/master/client/index.js#L81.

@bebraw What do you think, should we tweak the feature behavior @ `webpack-dev-server`, so it matches this inline comment as well as the intended behavior as per https://github.com/webpack/webpack-dev-server/issues/789, quoting:

> overlay: true would be the same as overlay: { errors: true, warnings: false }.