### PR TITLE
Formatting and reference link fixes

### DIFF
--- a/manuscript/output/02_multiple_pages.md
+++ b/manuscript/output/02_multiple_pages.md
@@ -184,6 +184,7 @@ leanpub-start-insert
 leanpub-end-insert
   } = {}
 ) => ({
+leanpub-start-insert
   entry,
 leanpub-end-insert
   plugins: [

--- a/manuscript/techniques/01_dynamic_loading.md
+++ b/manuscript/techniques/01_dynamic_loading.md
@@ -4,7 +4,7 @@ Even though you can get far with webpack's code splitting features covered in th
 
 ## Dynamic Loading with `require.context`
 
-[require.context](https://webpack.js.org/configuration/entry-context/#context) provides a general form of code splitting. Let's say you are writing a static site generator on top of webpack. You could model your site contents within a directory structure by having a `./pages/` directory which would contain the Markdown files.
+[require.context](https://webpack.js.org/api/module-methods/#require-context) provides a general form of code splitting. Let's say you are writing a static site generator on top of webpack. You could model your site contents within a directory structure by having a `./pages/` directory which would contain the Markdown files.
 
 Each of these files would have a YAML frontmatter for their metadata. The url of each page could be determined based on the filename and mapped as a site. To model the idea using `require.context`, you could end up with code as below:
 


### PR DESCRIPTION
1. Correct API reference link for `require.context` module method was given.
1. Formatting was fixed by adding an opening tag for `leanpub-insert` closing tag.