### PR TITLE
Fixed path for main stylesheet in autoprefixing section

### DIFF
--- a/manuscript/styling/04_autoprefixing.md
+++ b/manuscript/styling/04_autoprefixing.md
@@ -45,7 +45,7 @@ leanpub-end-insert
 
 To confirm that the setup works, we have to add something to autoprefix. Adjust the CSS:
 
-**app/main.css**
+**src/main.css**
 
 ```css
 ...


### PR DESCRIPTION
[Setting Up the Initial CSS](https://survivejs.com/webpack/styling/loading/#setting-up-the-initial-css) instructs to place the main stylesheet in `src/main.css`. This PR fixes the path in the `Setting Up Autoprefixing` section.

Thank you so much for your work and this book. I'm learning a ton with it.