### PR TITLE
fix(building): update clean-webpack-plugin usage

### DIFF
--- a/manuscript/building/04_tidying_up.md
+++ b/manuscript/building/04_tidying_up.md
@@ -26,6 +26,9 @@ Next, you need to define a function to wrap the basic idea. You could use the pl
 ...
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 
+// for clean-webpack-plugin@3.0.0, use named exported
+const { CleanWebpackPlugin } = require("clean-webpack-plugin"); 
+
 exports.clean = path => ({
   plugins: [new CleanWebpackPlugin()],
 });


### PR DESCRIPTION
For clean-webpack-plugin@3.0.0, use named export instead of default export.

Close #317 