### PR TITLE
refactor: update extractcss config

### DIFF
--- a/manuscript/styling/02_separating_css.md
+++ b/manuscript/styling/02_separating_css.md
@@ -39,6 +39,7 @@ exports.extractCSS = ({ options = {}, loaders = [] } = {}) => {
             { loader: MiniCssExtractPlugin.loader, options },
             "css-loader",
           ].concat(loaders),
+          sideEffects: true,
         },
       ],
     },


### PR DESCRIPTION
Adding `sideEffects: true` prevents `mini-css-extract-plugin` from not working when the `package.json` is configured with no sideEffects.